### PR TITLE
Add source links

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,6 +23,12 @@ export default ({ examples }) => {
 							<Link href={`/api/${example}`}>
 								<a>{example}</a>
 							</Link>
+							{' '}
+							(
+								<Link href={`https://github.com/vercel-community/deno/blob/master/api/${example}.ts`}>
+									<a target="_blank" rel="noopener noreferrer">Source</a>
+								</Link>
+							)
 						</li>
 					))}
 				</ul>


### PR DESCRIPTION
Just a suggestion. We could add links to source code for individual examples.

See [deployed](https://vercel-community-deno-pe5cny4kt-anishkny.vercel.app/).

<img width="663" alt="Screen Shot 2022-03-20 at 7 38 31 PM" src="https://user-images.githubusercontent.com/357499/159198492-49ebfc82-3302-452b-99e4-38f0d3780eb5.png">

