### PR TITLE
Use Git sha instead of "master" for the Source link

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { basename, extname, join } from 'path';
 
 export async function getStaticProps() {
+	console.log(process.env);
 	const apiDir = join(process.cwd(), 'api');
 	const apiFiles = await fs.promises.readdir(apiDir);
 	const examples = apiFiles

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,15 +3,15 @@ import Link from 'next/link';
 import { basename, extname, join } from 'path';
 
 export async function getStaticProps() {
-	console.log(process.env);
+	const sha = process.env.VERCEL_GIT_COMMIT_SHA || 'master';
 	const apiDir = join(process.cwd(), 'api');
 	const apiFiles = await fs.promises.readdir(apiDir);
 	const examples = apiFiles
 		.filter((f) => f.endsWith('.ts') || f.endsWith('.js'));
-	return { props: { examples } };
+	return { props: { sha, examples } };
 }
 
-export default function Index ({ examples }) {
+export default function Index ({ sha, examples }) {
 	return (
 		<div>
 			<p>Hello from Deno, powered by Vercel!</p>
@@ -25,7 +25,7 @@ export default function Index ({ examples }) {
 							</Link>
 							{' '}
 							(
-								<Link href={`https://github.com/vercel-community/deno/blob/master/api/${example}`}>
+								<Link href={`https://github.com/vercel-community/deno/blob/${sha}/api/${example}`}>
 									<a target="_blank" rel="noopener noreferrer">Source</a>
 								</Link>
 							)


### PR DESCRIPTION
Follow-up to #106 + #108 to use the Git sha in the link instead of `master`.