### PR TITLE
fix typo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ In this example, the `FOO` environment variable will be set to "bar" and `ANOTHE
 
 By default, dynamic imports (using the `import()` function during runtime) _**will fail**_. For most use-cases, this is fine since this feature is only necessary for rare use-cases.
 
-However, when dynamic imports _are_ required for your endpoint, the `DENO_DIR` enviorment variable will need to be set to "/tmp". This is required because the file system is read-only, within the Serverless Function runtime environment, _except_ for the "/tmp" dir. Because dynamic imports will require compilation at runtime, the deno cache directory needs to be writable.
+However, when dynamic imports _are_ required for your endpoint, the `DENO_DIR` environment variable will need to be set to "/tmp". This is required because the file system is read-only, within the Serverless Function runtime environment, _except_ for the "/tmp" dir. Because dynamic imports will require compilation at runtime, the deno cache directory needs to be writable.
 
 The recommended way of enabling this is to add an environment variable to the endpoint's shebang. For example:
 


### PR DESCRIPTION
Fix typo on "enviorment" word in README