### PR TITLE
Add support for `AWS_LAMBDA_EXEC_WRAPPER`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/yauzl-promise": "^2.1.0",
     "@typescript-eslint/eslint-plugin": "4.15.0",
     "@typescript-eslint/parser": "4.15.0",
-    "@vercel/build-utils": "^2.14.1-canary.5",
+    "@vercel/build-utils": "^5.2.0",
     "@vercel/frameworks": "^0.2.0",
     "@vercel/routing-utils": "^1.9.2",
     "eslint": "7.19.0",

--- a/src/bootstrap
+++ b/src/bootstrap
@@ -11,4 +11,4 @@ else
     export DENO_DIR="$LAMBDA_TASK_ROOT/.vercel/cache/deno"
 fi
 
-exec deno run $args ".vercel-deno-runtime.ts"
+exec ${AWS_LAMBDA_EXEC_WRAPPER-} deno run $args ".vercel-deno-runtime.ts"

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,6 +252,7 @@ export const build: BuildV3 = async ({
 		handler: entrypoint,
 		runtime: 'provided.al2',
 		environment: args.env,
+		supportsWrapper: true,
 	});
 
 	return { output };

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,10 +933,10 @@
     "@typescript-eslint/types" "4.31.0"
     eslint-visitor-keys "^2.0.0"
 
-"@vercel/build-utils@^2.14.1-canary.5":
-  version "2.14.1-canary.5"
-  resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-2.14.1-canary.5.tgz#77fa1917881fd0fcb9ad8580f688d58be9fff06f"
-  integrity sha512-ODFmy9K8FyJMpeCthtjmnzg2ooU2U/bApQhZ9sicVuDzXSdxJQj5uJLWe4mLdtcInzXCmWLFypy5ou4yBZ92ng==
+"@vercel/build-utils@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-5.2.0.tgz#4cbe06bf81c492ec65f3faa77b36a1c959cd1fad"
+  integrity sha512-sL3CeIwmjyT8brB+5OAVAFmdSnvMDO9BzzJb9AwW8T8bo/l8jfob3T3cp8qOB5ORlrwb60dNRO5giJfGWloOcA==
 
 "@vercel/frameworks@^0.2.0":
   version "0.2.0"


### PR DESCRIPTION
This adds support for the `AWS_LAMBDA_EXEC_WRAPPER` env var, which Vercel uses for the large environment variables implementation.