### PR TITLE
Upgrading Deno to 1.30.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * The default version of Deno that will be downloaded at build-time.
  */
-const DEFAULT_DENO_VERSION = 'v1.29.4';
+const DEFAULT_DENO_VERSION = 'v1.30.0';
 
 import { fileURLToPath, pathToFileURL } from 'url';
 import { spawn } from 'child_process';


### PR DESCRIPTION
For more detailed information about the release, please refer to: https://github.com/denoland/deno/releases/tag/v1.30.0