### PR TITLE
Remove legacy interfaces, implement Vercel style interface

### DIFF
--- a/api/dump.ts
+++ b/api/dump.ts
@@ -1,20 +1,7 @@
 #!/usr/bin/env deno run --location https://example.com/page
 import ms from 'https://esm.sh/ms@2.1.3';
-import { readerFromStreamReader } from 'https://deno.land/std@0.107.0/io/streams.ts';
-
-interface HeadersObject {
-	[name: string]: any;
-}
 
 const startTime = new Date();
-
-function headersToObject(headers: Headers): HeadersObject {
-	const obj: HeadersObject = {};
-	for (const [name, value] of headers.entries()) {
-		obj[name] = value;
-	}
-	return obj;
-}
 
 function urlToObject(url: URL) {
 	return {
@@ -32,7 +19,7 @@ function urlToObject(url: URL) {
 	};
 }
 
-function sortObject<T extends object>(obj: T): T {
+function sortObject<T extends Record<string, unknown>>(obj: T): T {
 	const sorted: T = Object.create(Object.getPrototypeOf(obj));
 	const keys = Object.keys(obj).sort() as (keyof T)[];
 	for (const k of keys) {
@@ -41,7 +28,8 @@ function sortObject<T extends object>(obj: T): T {
 	return sorted;
 }
 
-export default async ({ request }: Deno.RequestEvent) => {
+export default async (request: Request) => {
+	console.log(request);
 	const now = new Date();
 	const uptime = now.getTime() - startTime.getTime();
 	const url = new URL(request.url);
@@ -55,6 +43,8 @@ export default async ({ request }: Deno.RequestEvent) => {
 		}
 	}
 
+	const reqBody = await request.arrayBuffer();
+
 	const body = {
 		now: now.getTime(),
 		bootup: startTime.getTime(),
@@ -65,14 +55,11 @@ export default async ({ request }: Deno.RequestEvent) => {
 		request: {
 			method: request.method,
 			url: urlToObject(url),
-			headers: sortObject(headersToObject(request.headers)),
-			body: request.body
-				? new TextDecoder().decode(
-						await Deno.readAll(
-							readerFromStreamReader(request.body.getReader())
-						)
-				  )
-				: null,
+			headers: sortObject(Object.fromEntries(request.headers)),
+			body:
+				reqBody.byteLength > 0
+					? new TextDecoder().decode(reqBody)
+					: null,
 		},
 		response: {
 			status,

--- a/api/dump.ts
+++ b/api/dump.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env deno run --location https://example.com/page
 import ms from 'https://esm.sh/ms@2.1.3';
+import type { Handler } from "https://deno.land/std@0.177.0/http/server.ts";
 
 const startTime = new Date();
 
@@ -28,7 +29,7 @@ function sortObject<T extends Record<string, unknown>>(obj: T): T {
 	return sorted;
 }
 
-export default async (request: Request) => {
+const handler: Handler = async (request) => {
 	const now = new Date();
 	const uptime = now.getTime() - startTime.getTime();
 	const url = new URL(request.url);
@@ -81,3 +82,5 @@ export default async (request: Request) => {
 		},
 	});
 };
+
+export default handler;

--- a/api/dump.ts
+++ b/api/dump.ts
@@ -29,7 +29,6 @@ function sortObject<T extends Record<string, unknown>>(obj: T): T {
 }
 
 export default async (request: Request) => {
-	console.log(request);
 	const now = new Date();
 	const uptime = now.getTime() - startTime.getTime();
 	const url = new URL(request.url);

--- a/api/dynamic-import.ts
+++ b/api/dynamic-import.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env DENO_DIR=/tmp deno run --include-files ../util/**/*
 
-export default async ({ request }: Deno.RequestEvent) => {
+export default async (request: Request) => {
 	const name = new URL(request.url).searchParams.get('name') ?? 'a';
 	const mod = await import(`../util/${name}.ts`);
 	console.log({ name, mod });

--- a/api/javascript.js
+++ b/api/javascript.js
@@ -1,3 +1,3 @@
-export default (req) => {
-	req.respond({ body: 'Hello from JavaScript in Deno!' });
+export default (_req) => {
+	return new Response('Hello from JavaScript in Deno!');
 };

--- a/api/oak.ts
+++ b/api/oak.ts
@@ -1,10 +1,9 @@
-import { Application } from 'https://deno.land/x/oak@v9.0.0/mod.ts';
+import { Application } from 'https://deno.land/x/oak@v11.1.0/mod.ts';
 
 const app = new Application();
 
 app.use((ctx) => {
-	ctx.response.body = 'Hello World!';
-	console.log(ctx);
+	ctx.response.body = 'Hello World from Oak!';
 });
 
 export default app.handle;

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -40,8 +40,7 @@ async function toVercelResponse(res: Response): Promise<VercelResponsePayload> {
 	let body = '';
 	const bodyBuffer = await res.arrayBuffer();
 	if (bodyBuffer.byteLength > 0) {
-		const bytes = new Uint8Array(bodyBuffer);
-		body = base64.encode(bytes);
+		body = base64.encode(bodyBuffer);
 	}
 
 	return {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -28,10 +28,11 @@ function fromVercelRequest(payload: VercelRequestPayload): Request {
 		'x-forwarded-host'
 	)}`;
 	const url = new URL(payload.path, base);
+	const body = payload.body ? base64.decode(payload.body) : undefined;
 	return new Request(url.href, {
-		headers,
 		method: payload.method,
-		body: base64.decode(payload.body || ''),
+		headers,
+		body
 	});
 }
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1,40 +1,20 @@
-import * as base64 from 'https://deno.land/std@0.106.0/encoding/base64.ts';
-import * as stdHttpServer from 'https://deno.land/std@0.106.0/http/server.ts';
-import { TextProtoReader } from 'https://deno.land/std@0.106.0/textproto/mod.ts';
-import { readerFromStreamReader } from 'https://deno.land/std@0.106.0/io/streams.ts';
-import {
-	BufReader,
-	BufWriter,
-} from 'https://deno.land/std@0.106.0/io/bufio.ts';
-
-export interface HeadersObj {
-	[name: string]: string;
-}
-
-export interface RequestEvent {
-	readonly request: Request;
-	respondWith(r: Response | Promise<Response>): Promise<void>;
-}
+import * as base64 from 'https://deno.land/std@0.177.0/encoding/base64.ts';
 
 export interface VercelRequestPayload {
 	method: string;
 	path: string;
-	headers: HeadersObj;
+	headers: Record<string, string>;
 	body: string;
 }
 
 export interface VercelResponsePayload {
 	statusCode: number;
-	headers: HeadersObj;
+	headers: Record<string, string>;
 	encoding: 'base64';
 	body: string;
 }
 
-export type StdHandler = (
-	req: stdHttpServer.ServerRequest
-) => Promise<stdHttpServer.Response | void>;
-export type NativeHandler = (event: RequestEvent) => Promise<Response | void>;
-export type Handler = StdHandler | NativeHandler;
+export type Handler = (request: Request) => Response | Promise<Response>;
 
 const RUNTIME_PATH = '2018-06-01/runtime';
 
@@ -42,131 +22,33 @@ const { _HANDLER, ENTRYPOINT, AWS_LAMBDA_RUNTIME_API } = Deno.env.toObject();
 
 Deno.env.delete('SHLVL');
 
-function headersToObject(headers: Headers): HeadersObj {
-	const obj: HeadersObj = {};
-	for (const [name, value] of headers.entries()) {
-		obj[name] = value;
-	}
-	return obj;
+function fromVercelRequest(payload: VercelRequestPayload): Request {
+	const headers = new Headers(payload.headers);
+	const base = `${headers.get('x-forwarded-proto')}://${headers.get(
+		'x-forwarded-host'
+	)}`;
+	const url = new URL(payload.path, base);
+	return new Request(url.href, {
+		headers,
+		method: payload.method,
+		body: base64.decode(payload.body || ''),
+	});
 }
 
-class Deferred<T> {
-	promise: Promise<T>;
-	resolve!: (v: T) => void;
-	reject!: (v: any) => void;
-
-	constructor() {
-		this.promise = new Promise<T>((res, rej) => {
-			this.resolve = res;
-			this.reject = rej;
-		});
-	}
-}
-
-class VercelRequest
-	extends stdHttpServer.ServerRequest
-	implements RequestEvent
-{
-	readonly request: Request;
-	#response: Deferred<Response>;
-	#output: Deno.Buffer;
-
-	constructor(data: VercelRequestPayload) {
-		super();
-
-		this.#response = new Deferred();
-
-		// Request headers
-		const headers = new Headers();
-		for (const [name, value] of Object.entries(data.headers)) {
-			if (typeof value === 'string') {
-				headers.set(name, value);
-			}
-			// TODO: handle multi-headers?
-		}
-
-		const base = `${headers.get('x-forwarded-proto')}://${headers.get(
-			'x-forwarded-host'
-		)}`;
-		const url = new URL(data.path, base);
-
-		// Native HTTP server interface
-		this.request = new Request(url.href, {
-			headers,
-			method: data.method,
-		});
-
-		// Legacy `std` HTTP server interface
-		const input = new Deno.Buffer(base64.decode(data.body || ''));
-		this.#output = new Deno.Buffer(new Uint8Array(6000000)); // 6 MB
-
-		// req.conn
-		this.r = new BufReader(input, input.length);
-		this.method = data.method;
-		this.url = data.path;
-		this.proto = 'HTTP/1.1';
-		this.protoMinor = 1;
-		this.protoMajor = 1;
-		this.headers = headers;
-		this.w = new BufWriter(this.#output);
+async function toVercelResponse(res: Response): Promise<VercelResponsePayload> {
+	let body = '';
+	const bodyBuffer = await res.arrayBuffer();
+	if (bodyBuffer.byteLength > 0) {
+		const bytes = new Uint8Array(bodyBuffer);
+		body = base64.encode(bytes);
 	}
 
-	respondWith = async (r: Response | Promise<Response>): Promise<void> => {
-		const response = await r;
-		this.#response.resolve(response);
+	return {
+		statusCode: res.status,
+		headers: Object.fromEntries(res.headers),
+		encoding: 'base64',
+		body,
 	};
-
-	async waitForStdResponse(): Promise<VercelResponsePayload> {
-		const responseError = await this.done;
-		if (responseError) {
-			throw responseError;
-		}
-
-		const bufr = new BufReader(this.#output, this.#output.length);
-		const tp = new TextProtoReader(bufr);
-		const firstLine = await tp.readLine(); // e.g. "HTTP/1.1 200 OK"
-		if (firstLine === null) throw new Deno.errors.UnexpectedEof();
-
-		const resHeaders = await tp.readMIMEHeader();
-		if (resHeaders === null) throw new Deno.errors.UnexpectedEof();
-
-		const body = await bufr.readFull(new Uint8Array(bufr.buffered()));
-		if (!body) throw new Deno.errors.UnexpectedEof();
-
-		await this.finalize();
-
-		return {
-			statusCode: parseInt(firstLine.split(' ', 2)[1], 10),
-			headers: headersToObject(resHeaders),
-			encoding: 'base64',
-			body: base64.encode(body),
-		};
-	}
-
-	async waitForNativeResponse(): Promise<VercelResponsePayload> {
-		const res = await this.#response.promise;
-
-		const reader = res.body?.getReader();
-		let body = '';
-		if (reader) {
-			const bytes = await Deno.readAll(readerFromStreamReader(reader));
-			body = base64.encode(bytes);
-		}
-
-		return {
-			statusCode: res.status,
-			headers: headersToObject(res.headers),
-			encoding: 'base64',
-			body,
-		};
-	}
-
-	waitForResult(): Promise<VercelResponsePayload> {
-		return Promise.race([
-			this.waitForStdResponse(),
-			this.waitForNativeResponse(),
-		]);
-	}
 }
 
 async function processEvents(): Promise<void> {
@@ -174,7 +56,7 @@ async function processEvents(): Promise<void> {
 
 	while (true) {
 		const { event, awsRequestId } = await nextInvocation();
-		let result;
+		let result: VercelResponsePayload;
 		try {
 			if (!handler) {
 				const mod = await import(`./${_HANDLER}`);
@@ -184,20 +66,12 @@ async function processEvents(): Promise<void> {
 				}
 			}
 
-			const data = JSON.parse(event.body);
-			const req = new VercelRequest(data);
+			const payload = JSON.parse(event.body) as VercelRequestPayload;
+			const req = fromVercelRequest(payload);
 
 			// Run user code
 			const res = await handler(req);
-			if (res) {
-				if (res instanceof Response) {
-					req.respondWith(res);
-				} else {
-					req.respond(res);
-				}
-			}
-
-			result = await req.waitForResult();
+			result = await toVercelResponse(res);
 		} catch (e: unknown) {
 			const err = e instanceof Error ? e : new Error(String(e));
 			console.error(err);
@@ -253,7 +127,7 @@ async function invokeResponse(
 	}
 }
 
-async function invokeError(err: Error, awsRequestId: string) {
+function invokeError(err: Error, awsRequestId: string) {
 	return postError(`invocation/${awsRequestId}/error`, err);
 }
 


### PR DESCRIPTION
Previously there were two interfaces supported:

```ts
import { ServerRequest } from 'https://deno.land/std@0.106.0/http/server.ts';

export default function (request: ServerRequest) {
  console.log(request.url);
  request.respond({ body: '...' });
}
```

```ts
export default function (event: Deno.RequestEvent) {
  console.log(event.request.url);
  event.respondWith(new Response('...'));
}
```

Supporting both interfaces has been hard/hacky to maintain, and in 2023 there is a now a more standardized interface that also fits better with the Vercel style. This PR implements this new interface:

```ts
export default function (request: Request) {
  console.log(request.url);
  return new Response('...');
}
```

This new interface matches the Vercel Edge runtime syntax. The `Request` object is passed directly as the first parameter, and a `Response` instance is expected to be returned from the handler. The runtime is a lot cleaner because the legacy code has been removed. There are also less URL imports needed since Deno supports these standard classes directly (only `base64` still needs to be imported).

Closes #104.