### PR TITLE
Support multiple response headers with the same name

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -41,7 +41,6 @@ function fromVercelRequest(payload: VercelRequestPayload): Request {
 }
 
 function headersToVercelHeaders(headers: Headers): VercelResponseHeaders {
-	console.log(headers);
 	const h: VercelResponseHeaders = {};
 	for (const [name, value] of headers) {
 		const cur = h[name];
@@ -53,7 +52,6 @@ function headersToVercelHeaders(headers: Headers): VercelResponseHeaders {
 			h[name] = value;
 		}
 	}
-	console.log(h);
 	return h;
 }
 


### PR DESCRIPTION
Make it so that this works as expected:

```ts
export default function () {
  return new Response(null, {
    headers: [
      ["Set-Cookie", "foo=bar"],
      ["Set-Cookie", "sessionId=38afes7a8"],
    ],
  });
}
```